### PR TITLE
Update contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ Each available event has parameters which are stored in an editable xml file. Th
 
 ## Contribution guidelines
 When making a change, please follow these steps to maintain code integrity:
-* Create a new branch from master to make your changes 
-* Compile and test your changes
-* If successful, merge to the test branch, with your results, and request a review by another developer
-* Once verified by a second developer, merge the changes to the master branch
+* Create a new branch from master to your own fork. DO NOT create new branches on the main repo. 
+* Compile and test your changes on your fork where possible.
+* If successful, merge to the test (or dev) branch, with a comment explaining your results, and request a review by another member of the organisation (anyone will do!)
+* Once verified by a second developer, they can merge changes to the master branch.
 
 Code changes should never be commmitted directly to the master branch without testing and review.
+Full guidelines will be added here later, with more detail for those who are less experienced with Git.


### PR DESCRIPTION
Yes yes, I'm breaking the guideine I just added. But I figure this is probably a good way to delineate README updates from other changes. So any changes to the README can be added to this branch moving forward, please don't delete this one. 

To clarify the reasoning behind this, not creating new branches on the main repo keeps things relatively simple, otherwise you end up with several branches for minor changes because of the review restriction. Just do all your editing on your own fork and merge later. The review process (and please make sure you actually request a reviewer) makes sure we can all maintain code integrity, which is necessary on a collaborative project. I'm not doing this to be difficult, I promise. 

Also, please note that the restrictions only apply to the master branch, so if it becomes absolutely necessary to move away from this community sourced model, you can always merge all the branches into a single branch on a new repo.